### PR TITLE
Fix Remove BEAM Watcher Regression

### DIFF
--- a/src/main/webapp/WEB-INF/views/inventory/watchers.jsp
+++ b/src/main/webapp/WEB-INF/views/inventory/watchers.jsp
@@ -82,7 +82,7 @@
                     <c:forEach items="${watcherList}" var="watcher">
                         <tr data-username="${fn:escapeXml(watcher.watcherPK.username)}" data-facility-id="${watcher.watcherPK.facility.facilityId}">
                             <td><c:out value="${watcher.watcherPK.facility.name}"/></td>
-                            <td><c:out value="${watcher.watcherPK.operationsType.label}"/></td>
+                            <td><c:out value="${watcher.watcherPK.operationsType}"/></td>
                             <td><c:out value="${s:formatUsername(watcher.watcherPK.username)}"/></td>
                         </tr>
                     </c:forEach>


### PR DESCRIPTION
Fixes #45

This fixes the regression introduced in this commit:
https://github.com/JeffersonLab/jam/commit/625fadc17c27c2b8add3e28491f0dc695232a6ff#diff-f7c74855a5849ae2294218bc51d7d1d678cf02701ed32cc9956ac0fb20f9d393R85

It was requested to provide an alternate label to OperationTypes (SRF instead of RF).  Ironically this request was reversed.   On reserve cleanup concept of type label was left, and it had consequences.