### PR TITLE
Open new dialog on icon click

### DIFF
--- a/src/main/webapp/WEB-INF/tags/beam-operations-panel.tag
+++ b/src/main/webapp/WEB-INF/tags/beam-operations-panel.tag
@@ -100,6 +100,7 @@
                 </td>
                 <c:if test="${not isHistory}">
                     <td class="icon-cell">
+                        <a class="dialog-opener" href="${pageContext.request.contextPath}/verifications/destination?destinationId=${destination.beamDestinationId}&notEditable=Y&simple=Y">
                         <c:choose>
                             <c:when test="${destination.verification.verificationStatusId eq 1}">
                                 <span title="Verified" class="small-icon verified-icon"></span>
@@ -111,6 +112,7 @@
                                 <span title="Not Verified" class="small-icon not-verified-icon"></span>
                             </c:otherwise>
                         </c:choose>
+                        </a>
                         <c:if test="${destination.verification.verificationStatusId ne 100}">
                             <span class="expiring-soon" style="<c:out value="${jam:isExpiringSoon(destination.verification.expirationDate) ? 'display: inline-block;' : 'display: none;'}"/>">(Expiring Soon)</span>
                         </c:if>

--- a/src/main/webapp/WEB-INF/tags/rf-operations-panel.tag
+++ b/src/main/webapp/WEB-INF/tags/rf-operations-panel.tag
@@ -78,6 +78,7 @@
                 </td>
                 <c:if test="${not isHistory}">
                     <td class="icon-cell">
+                        <a class="dialog-opener" href="${pageContext.request.contextPath}/verifications/segment?segmentId=${segment.getRFSegmentId()}&notEditable=Y&simple=Y">
                             <c:choose>
                                 <c:when test="${segment.verification.verificationStatusId eq 1}">
                                     <span title="Verified" class="small-icon verified-icon"></span>
@@ -89,6 +90,7 @@
                                     <span title="Not Verified" class="small-icon not-verified-icon"></span>
                                 </c:otherwise>
                             </c:choose>
+                        </a>
                         <c:if test="${segment.verification.verificationStatusId ne 100}">
                             <span class="expiring-soon" style="<c:out value="${jam:isExpiringSoon(segment.verification.expirationDate) ? 'display: inline-block;' : 'display: none;'}"/>">(Expiring Soon)</span>
                         </c:if>

--- a/src/main/webapp/WEB-INF/tags/verification-panel.tag
+++ b/src/main/webapp/WEB-INF/tags/verification-panel.tag
@@ -44,10 +44,12 @@
             </c:if>
             <th><c:out value="${rowKey}"/></th>
             <th>Verified</th>
-            <th>Components</th>
-            <th>Comments</th>
             <th>Expiration Date</th>
-            <th class="audit-header">Audit</th>
+            <c:if test="${param.simple ne 'Y'}">
+                <th>Components</th>
+                <th>Comments</th>
+                <th class="audit-header">Audit</th>
+            </c:if>
         </tr>
         </thead>
         <tbody>
@@ -77,6 +79,8 @@
                     <div class="verified-date"><fmt:formatDate pattern="${s:getFriendlyDateTimePattern()}" value="${verification.verificationDate}"/></div>
                     <div class="verified-by"><c:out value="${s:formatUsername(verification.verifiedBy)}"/></div>
                 </td>
+                <td><fmt:formatDate pattern="${s:getFriendlyDateTimePattern()}" value="${verification.expirationDate}"/></td>
+                <c:if test="${param.simple ne 'Y'}">
                 <td>
                     <c:forEach items="${verification.componentList}" var="component">
                         <div class="component-status" data-id="${component.componentId}">
@@ -101,8 +105,8 @@
                         </div>
                     </c:if>
                 </td>
-                <td><fmt:formatDate pattern="${s:getFriendlyDateTimePattern()}" value="${verification.expirationDate}"/></td>
                 <td><a class="${groupByOperation ? 'dialog-opener' : 'partial-support'}" href="${pageContext.request.contextPath}/verifications/control/${historyPathSuffix}=${verification[operationsId]}" title="Click for verification history">History</a></td>
+                </c:if>
             </tr>
         </c:forEach>
         </tbody>

--- a/src/main/webapp/WEB-INF/views/control-verification.jsp
+++ b/src/main/webapp/WEB-INF/views/control-verification.jsp
@@ -106,8 +106,8 @@
                                     </c:choose>
                                     <c:out value="${fv.getFacilityControlVerificationPK().facility.name}"/>
                                     <c:if test="${fv.verificationStatusId ne 100}">
-                                        <span title="Earliest Control Expiration">
-                                            <fmt:formatDate value="${fv.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>
+                                        <span class="title-expiration" title="Earliest Control Expiration">
+                                            {Expires: <fmt:formatDate value="${fv.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>}
                                         </span>
                                         <span class="expiring-soon" style="<c:out value="${jam:isExpiringSoon(fv.expirationDate) ? 'display: inline-block;' : 'display: none;'}"/>">(Expiring Soon)</span>
                                     </c:if>

--- a/src/main/webapp/WEB-INF/views/destination-verification.jsp
+++ b/src/main/webapp/WEB-INF/views/destination-verification.jsp
@@ -4,7 +4,7 @@
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <%@taglib prefix="s" uri="http://jlab.org/jsp/smoothness" %>
 <%@taglib prefix="jam" uri="http://jlab.org/jam/functions"%>
-<c:set var="title" value="${fn:escapeXml(destination.name)} Destination Verification"/>
+<c:set var="title" value="Destination Verification"/>
 <%@taglib prefix="t" tagdir="/WEB-INF/tags"%>
 <s:page title="${title}">
     <jsp:attribute name="stylesheets">
@@ -38,6 +38,7 @@
                     </li>
                     <li>
                         <form method="get" action="destination">
+                            <label>Destination</label>
                             <select name="destinationId" class="change-submit">
                                 <c:forEach items="${destinationList}" var="destination">
                                     <option value="${destination.beamDestinationId}"${param.destinationId eq destination.beamDestinationId ? ' selected="selected"' : ''}><c:out value="${destination.facility.name} / ${destination.name}"/></option>
@@ -55,11 +56,10 @@
                 </c:url>
                 <a class="dialog-only-inline-block" href="${url}" target="_blank">Open in new tab</a>
             </div>
-            <h2 class="page-header-title"><c:out value="${title}"/></h2>
             <c:choose>
                 <c:when test="${destination ne null}">
                     <div>
-                        <h3>
+                        <h2 class="page-header-title">
                             <c:choose>
                                 <c:when test="${destination.verification.verificationStatusId eq 1}">
                                     <span title="Verified" class="small-icon baseline-small-icon verified-icon"></span>
@@ -71,14 +71,14 @@
                                     <span title="Not Verified" class="small-icon baseline-small-icon not-verified-icon"></span>
                                 </c:otherwise>
                             </c:choose>
-                            Credited Control Verifications
+                            <c:out value="${fn:escapeXml(destination.name)}"/>
                             <c:if test="${destination.verification.verificationStatusId ne 100}">
                                 <span title="Earliest Control Expiration">
                                     <fmt:formatDate value="${destination.verification.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>
                                 </span>
                                 <span class="expiring-soon" style="<c:out value="${jam:isExpiringSoon(destination.verification.expirationDate) ? 'display: inline-block;' : 'display: none;'}"/>">(Expiring Soon)</span>
                             </c:if>
-                        </h3>
+                        </h2>
                         <c:choose>
                             <c:when test="${fn:length(destination.beamControlVerificationList) < 1}">
                                 None

--- a/src/main/webapp/WEB-INF/views/destination-verification.jsp
+++ b/src/main/webapp/WEB-INF/views/destination-verification.jsp
@@ -73,12 +73,13 @@
                             </c:choose>
                             <c:out value="${fn:escapeXml(destination.name)}"/>
                             <c:if test="${destination.verification.verificationStatusId ne 100}">
-                                <span title="Earliest Control Expiration">
-                                    <fmt:formatDate value="${destination.verification.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>
+                                <span class="title-expiration" title="Earliest Control Expiration">
+                                    {Expires: <fmt:formatDate value="${destination.verification.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>}
                                 </span>
                                 <span class="expiring-soon" style="<c:out value="${jam:isExpiringSoon(destination.verification.expirationDate) ? 'display: inline-block;' : 'display: none;'}"/>">(Expiring Soon)</span>
                             </c:if>
                         </h2>
+                        <div class="verification-wrap">
                         <c:choose>
                             <c:when test="${fn:length(destination.beamControlVerificationList) < 1}">
                                 None
@@ -87,6 +88,7 @@
                                 <t:verification-panel operationsType="beam" operationsList="${destination.beamControlVerificationList}" groupByOperation="true"/>
                             </c:otherwise>
                         </c:choose>
+                        </div>
                     </div>
                 </c:when>
                 <c:otherwise>                   

--- a/src/main/webapp/WEB-INF/views/segment-verification.jsp
+++ b/src/main/webapp/WEB-INF/views/segment-verification.jsp
@@ -5,7 +5,7 @@
 <%@taglib prefix="s" uri="http://jlab.org/jsp/smoothness" %>
 <%@taglib prefix="jam" uri="http://jlab.org/jam/functions"%>
 <%@taglib prefix="t" tagdir="/WEB-INF/tags"%>
-<c:set var="title" value="${fn:escapeXml(segment.name)} Segment Verification"/>
+<c:set var="title" value="Segment Verification"/>
 <s:page title="${title}">
     <jsp:attribute name="stylesheets">
         <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/resources/v${initParam.releaseNumber}/css/verification-panel.css"/>
@@ -38,6 +38,7 @@
                     </li>
                     <li>
                         <form method="get" action="segment">
+                            <label>Segment</label>
                             <select name="segmentId" class="change-submit">
                                 <c:forEach items="${segmentList}" var="segment">
                                     <option value="${segment.getRFSegmentId()}"${param.segmentId eq segment.getRFSegmentId() ? ' selected="selected"' : ''}><c:out value="${segment.facility.name} / ${segment.name}"/></option>
@@ -55,11 +56,10 @@
                 </c:url>
                 <a class="dialog-only-inline-block" href="${url}" target="_blank">Open in new tab</a>
             </div>
-            <h2 class="page-header-title"><c:out value="${title}"/></h2>
             <c:choose>
                 <c:when test="${segment ne null}">
                     <div>
-                        <h3>
+                        <h2 class="page-header-title">
                             <c:choose>
                                 <c:when test="${segment.verification.verificationStatusId eq 1}">
                                     <span title="Verified" class="small-icon baseline-small-icon verified-icon"></span>
@@ -71,14 +71,14 @@
                                     <span title="Not Verified" class="small-icon baseline-small-icon not-verified-icon"></span>
                                 </c:otherwise>
                             </c:choose>
-                            Credited Control Verifications
+                            <c:out value="${fn:escapeXml(segment.name)}"/>
                             <c:if test="${segment.verification.verificationStatusId ne 100}">
                                 <span title="Earliest Control Expiration">
                                     <fmt:formatDate value="${segment.verification.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>
                                 </span>
                                 <span class="expiring-soon" style="<c:out value="${jam:isExpiringSoon(segment.verification.expirationDate) ? 'display: inline-block;' : 'display: none;'}"/>">(Expiring Soon)</span>
                             </c:if>
-                        </h3>
+                        </h2>
                         <c:choose>
                             <c:when test="${fn:length(segment.getRFControlVerificationList()) < 1}">
                                 None

--- a/src/main/webapp/WEB-INF/views/segment-verification.jsp
+++ b/src/main/webapp/WEB-INF/views/segment-verification.jsp
@@ -73,12 +73,13 @@
                             </c:choose>
                             <c:out value="${fn:escapeXml(segment.name)}"/>
                             <c:if test="${segment.verification.verificationStatusId ne 100}">
-                                <span title="Earliest Control Expiration">
-                                    <fmt:formatDate value="${segment.verification.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>
+                                <span class="title-expiration" title="Earliest Control Expiration">
+                                    {Expires: <fmt:formatDate value="${segment.verification.expirationDate}" pattern="${s:getFriendlyDateTimePattern()}"/>}
                                 </span>
                                 <span class="expiring-soon" style="<c:out value="${jam:isExpiringSoon(segment.verification.expirationDate) ? 'display: inline-block;' : 'display: none;'}"/>">(Expiring Soon)</span>
                             </c:if>
                         </h2>
+                        <div class="verification-wrap">
                         <c:choose>
                             <c:when test="${fn:length(segment.getRFControlVerificationList()) < 1}">
                                 None
@@ -87,6 +88,7 @@
                                 <t:verification-panel operationsType="rf" operationsList="${segment.getRFControlVerificationList()}" groupByOperation="true"/>
                             </c:otherwise>
                         </c:choose>
+                        </div>
                     </div>
                 </c:when>
                 <c:otherwise>                   

--- a/src/main/webapp/WEB-INF/views/verification-history/destination-history.jsp
+++ b/src/main/webapp/WEB-INF/views/verification-history/destination-history.jsp
@@ -25,6 +25,12 @@
             </ul>
         </div>        
         <section>
+            <div class="top-right-box">
+                <c:url value="/verifications/control/destination-history" var="url">
+                    <c:param name="beamControlVerificationId" value="${param.beamControlVerificationId}"/>
+                </c:url>
+                <a class="dialog-only-inline-block" href="${url}" target="_blank">Open in new tab</a>
+            </div>
             <div>
                 <h3>Credited Control</h3>
                 <c:out value="${verification.creditedControl.name}"/>

--- a/src/main/webapp/WEB-INF/views/verification-history/segment-history.jsp
+++ b/src/main/webapp/WEB-INF/views/verification-history/segment-history.jsp
@@ -25,6 +25,12 @@
             </ul>
         </div>        
         <section>
+            <div class="top-right-box">
+                <c:url value="/verifications/control/segment-history" var="url">
+                    <c:param name="rfControlVerificationId" value="${param.rfControlVerificationId}"/>
+                </c:url>
+                <a class="dialog-only-inline-block" href="${url}" target="_blank">Open in new tab</a>
+            </div>
             <div>
                 <h3>Credited Control</h3>
                 <c:out value="${verification.creditedControl.name}"/>

--- a/src/main/webapp/resources/css/verification-panel.css
+++ b/src/main/webapp/resources/css/verification-panel.css
@@ -76,6 +76,20 @@ ul.ui-autocomplete {
     margin: 0;
     padding: 0;
 }
+#facility-control-verification-list li {
+    margin-top: 8px;
+    font-size: 24px;
+}
 .editable-row-table tr.selected-row a {
     color: red;
+}
+.verification-wrap {
+    margin-top: 1em;
+}
+.title-expiration {
+    font-size: .5em;
+    font-style: italic;
+    vertical-align: super;
+    line-height: 1.0;
+    color: gray;
 }

--- a/src/main/webapp/resources/js/verification-panel.js
+++ b/src/main/webapp/resources/js/verification-panel.js
@@ -189,7 +189,7 @@ $(document).on("click", ".verify-button", function () {
             statusArray.push($(this).attr("data-status-id"));
             verificationDateArray.push($(".verified-date", value).text());
             verifiedByArray.push($(this).attr("data-verified-username"));
-            expirationDateArray.push($("td:nth-child(6)", value).text());
+            expirationDateArray.push($("td:nth-child(4)", value).text());
             commentsArray.push($(".comments-div", value).text());
             linkArray.push($(".doc-anchor", value).attr("href"));
         }


### PR DESCRIPTION
Fixes #58

Also includes tweaks to layout such that the new simple dialog view is simpler plus full dialog view too:
- Consolidated two page titles to one
- Moved Expiration Date column such that now the first three columns are permanent, and rest is truncated in the alternative "simple" dialog
- Calculated roll-up expiration date for Facility/Operation Type is now styled uniquely